### PR TITLE
Merge branch release/2.0.0 into develop

### DIFF
--- a/.changes/v2.0.0.md
+++ b/.changes/v2.0.0.md
@@ -1,9 +1,3 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
-
 ## [v2.0.0](https://github.com/ansidev/counter-analytics-vue/compare/v1.0.0...v2.0.0) (2025-05-09)
 
 ### Bug Fixes
@@ -35,11 +29,3 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - **github-actions:** add github workflows
 
 Full Changelog: [v1.0.0...v2.0.0](https://github.com/ansidev/counter-analytics-vue/compare/v1.0.0...v2.0.0)
-
-## v1.0.0 (2022-12-23)
-
-### Features
-
-- add implementation for the first version
-
-Full Changelog: [v1.0.0](https://github.com/ansidev/counter-analytics-vue/commits/v1.0.0)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Counter Analytics integration for Vue v3",
   "author": "Le Minh Tri <ansidev@gmail.com>",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "type": "module",
   "packageManager": "pnpm@10.10.0",
   "homepage": "https://github.com/ansidev/counter-analytics-vue",


### PR DESCRIPTION
This PR merges the branch `release/2.0.0` back into the branch `develop`.

This ensures that the updates on the branch `release/2.0.0`, i.e. CHANGELOG and manifest updates, are also present on the branch `develop`.